### PR TITLE
docs: fix "contributing" header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ building for particular Hive and Hive Thriftserver distributions.
 Please refer to the [Configuration Guide](http://spark.apache.org/docs/latest/configuration.html)
 in the online documentation for an overview on how to configure Spark.
 
-## Contributing
+## Contributing
 
 Please review the [Contribution to Spark guide](http://spark.apache.org/contributing.html)
 for information on how to get started contributing to the project.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix "contributing" header in README

## How was this patch tested?

### earlier

![screenshot from 2017-06-12 09-47-27](https://user-images.githubusercontent.com/13034406/27019267-8f453bae-4f54-11e7-8897-0f2b7338ed83.png)

### now

![screenshot from 2017-06-12 09-51-45](https://user-images.githubusercontent.com/13034406/27019314-272d0492-4f55-11e7-9eba-797102d78edd.png)
